### PR TITLE
allow discover_uaa to find correct server with symbol keys

### DIFF
--- a/lib/uaa/misc.rb
+++ b/lib/uaa/misc.rb
@@ -68,11 +68,10 @@ class Misc
   # @return [String] url of UAA (or the target itself if it didn't provide a response)
   def self.discover_uaa(target)
     info = server(target)
-    if info['links'] && info['links']['uaa']
-      info['links']['uaa']
-    else
-      target
-    end
+    links = info['links'] || info[:links]
+    uaa = links['uaa'] || links[:uaa]
+
+    uaa || target
   end
 
   # Gets the key from the server that is used to validate token signatures. If


### PR DESCRIPTION
The `discover_uaa` method doesn't return the correct uaa host when `symbolize_keys=true`

Here's the fix, with tests!
