### PR TITLE
Bugfix: discover_uaa wouldn't return target with no links supplied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc/
 coverage/
 spec_reports/
 vendor/
+.idea

--- a/lib/uaa/misc.rb
+++ b/lib/uaa/misc.rb
@@ -69,7 +69,7 @@ class Misc
   def self.discover_uaa(target)
     info = server(target)
     links = info['links'] || info[:links]
-    uaa = links['uaa'] || links[:uaa]
+    uaa = links && (links['uaa'] || links[:uaa])
 
     uaa || target
   end

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -68,6 +68,15 @@ module CF::UAA
         result.should == "https://uaa.cloudfoundry.com"
       end
 
+      context "when there is no 'links' key present" do
+        let(:response_body) { '{ "prompts" : ["one","two"]} ' }
+
+        it "returns the login url" do
+          result = Misc.discover_uaa("https://login.cloudfoundry.com")
+          result.should == "https://login.cloudfoundry.com"
+        end
+      end
+
       context "with symbol keys" do
         around do |example|
           CF::UAA::Misc.symbolize_keys = true


### PR DESCRIPTION
The pull request we sent this morning didn't cover this one rather important edge case, and breaks some of the cfoundry gem's tests. Here's a better one, with a new test to cover this case.
