### PR TITLE
Moving away from deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/uaa/token_coder.rb
+++ b/lib/uaa/token_coder.rb
@@ -42,7 +42,7 @@ class InvalidAudience < AuthError; end
 class TokenCoder
 
   def self.init_digest(algo) # @private
-    OpenSSL::Digest::Digest.new(algo.sub('HS', 'sha').sub('RS', 'sha'))
+    OpenSSL::Digest.new(algo.sub('HS', 'sha').sub('RS', 'sha'))
   end
 
   def self.normalize_options(opts) # @private


### PR DESCRIPTION
- It no longer spews deprecation warnings on Ruby 2.0+.
