### PR TITLE
Make a POST JSON request to UAA on auto-login

### DIFF
--- a/lib/uaa/token_issuer.rb
+++ b/lib/uaa/token_issuer.rb
@@ -192,9 +192,9 @@ class TokenIssuer
   # @param [String] redirect_uri (see #authcode_uri)
   # @return (see #authcode_uri)
   def autologin_uri(redirect_uri, credentials, scope = nil)
-    headers = {'content-type' => FORM_UTF8, 'accept' => JSON_UTF8,
+    headers = {'content-type' => JSON_UTF8, 'accept' => JSON_UTF8,
         'authorization' => Http.basic_auth(@client_id, @client_secret) }
-    body = Util.encode_form(credentials)
+    body = Util.json(credentials)
     reply = json_parse_reply(nil, *request(@target, :post, "/autologin", body, headers))
     raise BadResponse, "no autologin code in reply" unless reply['code']
     @target + authorize_path_args('code', redirect_uri, scope,

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -124,7 +124,7 @@ describe "UAA Integration:" do
         uri_parts[0].should == "#{logn}/oauth/authorize"
         params = Util.decode_form(uri_parts[1], :sym)
         params[:response_type].should == "code"
-        params[:client_id].should == @client_id
+        params[:client_id].should == @test_client
         params[:scope].should be_nil
         params[:redirect_uri].should == redir_uri
         params[:state].should_not be_nil


### PR DESCRIPTION
The changes made to UAA on 9/16 (see https://github.com/cloudfoundry/uaa/compare/9429d16...4a77055) made the UAA ignore the form request type(`application/x-www-form-urlencoded;charset=utf-8`).

This commit changes the `#autologin_uri` method to make a POST request with content type `appliaction/json` so the UAA instance will accept the request.