### PR TITLE
Dynamically access parsed_reply hash using key of given style

### DIFF
--- a/lib/uaa/http.rb
+++ b/lib/uaa/http.rb
@@ -113,7 +113,7 @@ module Http
     end
     parsed_reply = Util.json_parse(body, style)
     if status >= 400
-      raise parsed_reply && parsed_reply['error'] == 'invalid_token' ?
+      raise parsed_reply && parsed_reply[Util.hash_key('error', style)] == 'invalid_token' ?
           InvalidToken.new(parsed_reply) : TargetError.new(parsed_reply), 'error response'
     end
     parsed_reply


### PR DESCRIPTION
Consumers of this gem can pass a "style" argument (see: https://github.com/cloudfoundry/cf-uaa-lib/blob/master/lib/uaa/util.rb#L54) which causes the keys of the `parsed_reply` hash to be converted to the given style.  So if someone passes `:sym` as their style, the error handling here will break.