### PR TITLE
Do not change case of includeInactive in scim#query

### DIFF
--- a/lib/uaa/scim.rb
+++ b/lib/uaa/scim.rb
@@ -61,7 +61,8 @@ class Scim
         'externalid' => 'externalId',
         'phonenumbers' => 'phoneNumbers',
         'startindex' => 'startIndex',
-        'zoneid' => 'zoneId'
+        'zoneid' => 'zoneId',
+        'includeinactive' => 'includeInactive'
     }[kd]
     kc || kd
   end

--- a/spec/scim_spec.rb
+++ b/spec/scim_spec.rb
@@ -113,6 +113,7 @@ describe Scim do
     subject.set_request_handler do |url, method, body, headers|
       url.should =~ %r{^#{@target}/Users\?}
       url.should =~ %r{[\?&]attributes=id(&|$)}
+      url.should =~ %r{[\?&]includeInactive=true(&|$)}
       url.should =~ %r{[\?&]startIndex=[12](&|$)}
       method.should == :get
       check_headers(headers, nil, :json, nil)
@@ -121,7 +122,7 @@ describe Scim do
         '{"TotalResults":2,"ItemsPerPage":1,"StartIndex":2,"RESOURCES":[{"id":"id67890"}]}'
       [200, reply, {'content-type' => 'application/json'}]
     end
-    result = subject.all_pages(:user, :attributes => 'id')
+    result = subject.all_pages(:user, :attributes => 'id', :includeInactive => true)
     [result[0]['id'], result[1]['id']].to_set.should == ['id12345', 'id67890'].to_set
   end
 


### PR DESCRIPTION
The `force_case` method was preventing us from including the `includeInactive` query param when attempting to hit https://docs.cloudfoundry.org/api/uaa/version/4.7.0/index.html#lookup-user-ids-usernames.

This adds it to the list of "special" params that shouldn't be force downcased.

Semi-relevant CAPI story:
[#150147189](https://www.pivotaltracker.com/story/show/150147189)

Thanks!
Tim && @ljfranklin 