### PR TITLE
explicit TokenCoder.decode_token_expiry

### DIFF
--- a/lib/uaa/token_coder.rb
+++ b/lib/uaa/token_coder.rb
@@ -123,6 +123,17 @@ class TokenCoder
     payload
   end
 
+  # Decodes a JWT token to extract its expiry time
+  # @param [String] token A JWT token as returned by {TokenCoder.encode}
+  # @return [Integer] exp expiry timestamp
+  def self.decode_token_expiry(token)
+    segments = token.split('.')
+    raise InvalidTokenFormat, "Not enough or too many segments" unless [2,3].include? segments.length
+    header_segment, payload_segment, crypto_segment = segments
+    payload = Util.json_decode64(payload_segment, :sym)
+    payload[:exp]
+  end
+
   # Takes constant time to compare 2 strings (HMAC digests in this case)
   # to avoid timing attacks while comparing the HMAC digests
   # @param [String] a: the first digest to compare

--- a/spec/token_coder_spec.rb
+++ b/spec/token_coder_spec.rb
@@ -183,6 +183,12 @@ describe TokenCoder do
     info["id"].should_not be_nil
     info["email"].should == "olds@vmware.com"
   end
+
+  it "decodes only the expiry_at time" do
+    exp = Time.now.to_i + 60
+    tkn = subject.encode({'foo' => "bar", 'exp' => exp })
+    TokenCoder.decode_token_expiry("bEaReR #{tkn}").should == exp
+  end
 end
 
 end


### PR DESCRIPTION
This will help to avoid bugs like https://github.com/cloudfoundry/omniauth-uaa-oauth2/blob/319ed4ba2315ab379bfa32fd464411e3c963562b/lib/omniauth/strategies/cloudfoundry.rb#L190-L191