### PR TITLE
[WIP] Automatically look up /token_keys to decode access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 spec_reports/
 vendor/
 .idea
+tmp/

--- a/cf-uaa-lib.gemspec
+++ b/cf-uaa-lib.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
   s.add_development_dependency 'ci_reporter', '~> 1.9', '>= 1.9.2'
   s.add_development_dependency 'json_pure', '~> 1.8', '>= 1.8.1'
+  s.add_development_dependency 'webmock', '~> 3.4'
 
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -56,19 +56,23 @@ module CF::UAA
     end
 
     it 'times out the connection at the configured time for the scim' do
+      stub_request(:get, 'http://10.255.255.1/Users/admin').to_timeout
+
       expect {
         Timeout.timeout(default_http_client_timeout - 1) do
           scim.get(:user, "admin")
         end
-      }.to raise_error HTTPException
+      }.to raise_error HTTPClient::TimeoutError
     end
 
     it 'times out the connection at the configured time for the token issuer' do
+      stub_request(:post, 'http://10.255.255.1/oauth/token').to_timeout
+
       expect {
         Timeout.timeout(default_http_client_timeout - 1) do
           token_issuer.client_credentials_grant
         end
-      }.to raise_error HTTPException
+      }.to raise_error HTTPClient::TimeoutError
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,4 @@ if ENV['COVERAGE']
 end
 
 require 'rspec'
+require 'webmock/rspec'


### PR DESCRIPTION
* Optional:`TokenCoder.new(..., kid: "uaa-jwt-key-1").encode()` will add `kid` to header to indicate the name of the signing key used to encode the token
* `TokenCode.new(..., info: CF::UAA::Info.new(...)).decode(token)` will automatically lookup the UAA `/token_keys` endpoint, and use the token header's `kid` to find the public key for asymmetric verification of the signed token