### PR TITLE
CC ISSUE 2040

### DIFF
--- a/lib/uaa/version.rb
+++ b/lib/uaa/version.rb
@@ -14,6 +14,6 @@
 # Cloud Foundry namespace
 module CF
   module UAA
-    VERSION = '3.14.3'
+    VERSION = '3.14.4'
   end
 end


### PR DESCRIPTION
This change is necessary to realise a solution for the following Issue, which was opened in the Cloud Controller: https://github.com/cloudfoundry/cloud_controller_ng/issues/2040

The change does the following:
- Extend "TokenExpired" exception by an optional decoded token attribute
- Change the function "decode_at_reference_time" to accept a third parameter, which, if set to true, will return the decoded token within the TokenExpired exception. Other exceptions behaviour remain the same.
- Implement the function "decode_at_reference_time_exp_warn_only" in class "TokenCoder" which can be called by the CC

Short explanation why this is needed:
- After the CC gets back the decoded token further checks like checking the UAA issuer are executed
- Until now, if the token is expired, the uaa_lib will only throw an exception and the CC can't access the decoded token
- In the CC we want to handle expired, but in general valid tokens more graceful. For this to work the CC needs to retrieve the decoded token together with the TokenExpired exception.

This is a proposal. We would be glad about feedback.