### PR TITLE
bump multi_json dependency

### DIFF
--- a/cf-uaa-lib.gemspec
+++ b/cf-uaa-lib.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # dependencies
-  s.add_dependency 'multi_json', '>= 1.12.1', '< 1.16'
+  s.add_dependency 'multi_json', '>=1.14.1', '< 1.16'
   s.add_dependency 'httpclient', '~> 2.8', '>= 2.8.2.4'
 
   s.add_development_dependency 'bundler', '~> 2.2'


### PR DESCRIPTION
Updating a project to use the latest version of ruby (3.0.1) and rails (6.1.4), it requires a multi_json dependency of  `>= 1.14.1`.