### PR TITLE
Add basic_auth option in authentication

### DIFF
--- a/lib/uaa/token_issuer.rb
+++ b/lib/uaa/token_issuer.rb
@@ -73,8 +73,7 @@ class TokenIssuer
     if scope = Util.arglist(params.delete(:scope))
       params[:scope] = Util.strlist(scope)
     end
-    headers = {'content-type' => FORM_UTF8, 'accept' => JSON_UTF8,
-        'authorization' => Http.basic_auth(@client_id, @client_secret) }
+    headers = {'content-type' => FORM_UTF8, 'accept' => JSON_UTF8}
     if @basic_auth
       headers['authorization'] = Http.basic_auth(@client_id, @client_secret)
     else

--- a/lib/uaa/token_issuer.rb
+++ b/lib/uaa/token_issuer.rb
@@ -13,6 +13,7 @@
 
 require 'securerandom'
 require 'uaa/http'
+require 'cgi'
 
 module CF::UAA
 
@@ -74,6 +75,12 @@ class TokenIssuer
     end
     headers = {'content-type' => FORM_UTF8, 'accept' => JSON_UTF8,
         'authorization' => Http.basic_auth(@client_id, @client_secret) }
+    if @basic_auth
+      headers['authorization'] = Http.basic_auth(@client_id, @client_secret)
+    else
+      headers['X-CF-ENCODED-CREDENTIALS'] = 'true'
+      headers['authorization'] = Http.basic_auth(CGI.escape(@client_id), CGI.escape(@client_secret))
+    end
     reply = json_parse_reply(@key_style, *request(@token_target, :post,
         '/oauth/token', Util.encode_form(params), headers))
     raise BadResponse unless reply[jkey :token_type] && reply[jkey :access_token]
@@ -109,6 +116,7 @@ class TokenIssuer
     @target, @client_id, @client_secret = target, client_id, client_secret
     @token_target = options[:token_target] || target
     @key_style = options[:symbolize_keys] ? :sym : nil
+    @basic_auth = options[:basic_auth] == true ? true : false
     initialize_http_options(options)
   end
 

--- a/spec/token_issuer_spec.rb
+++ b/spec/token_issuer_spec.rb
@@ -23,13 +23,13 @@ describe TokenIssuer do
 
   before do
     #Util.default_logger(:trace)
-    @issuer = TokenIssuer.new('http://test.uaa.target', 'test_client', 'test_secret', options)
+    @issuer = TokenIssuer.new('http://test.uaa.target', 'test_client', 'test!secret', options)
   end
 
   subject { @issuer }
 
   describe 'initialize' do
-    let(:options) { {http_proxy: 'http-proxy.com', https_proxy: 'https-proxy.com', skip_ssl_validation: true} }
+    let(:options) { {http_proxy: 'http-proxy.com', https_proxy: 'https-proxy.com', skip_ssl_validation: true, basic_auth: false} }
 
     it 'sets skip_ssl_validation' do
       subject.skip_ssl_validation == true
@@ -42,7 +42,8 @@ describe TokenIssuer do
       subject.set_request_handler do |url, method, body, headers|
         headers['content-type'].should =~ /application\/x-www-form-urlencoded/
         headers['accept'].should =~ /application\/json/
-        # TODO check basic auth header
+        headers['X-CF-ENCODED-CREDENTIALS'].should == 'true'
+        headers['authorization'].should == 'Basic dGVzdF9jbGllbnQ6dGVzdCUyMXNlY3JldA=='
         url.should == 'http://test.uaa.target/oauth/token'
         method.should == :post
         reply = {access_token: 'test_access_token', token_type: 'BEARER',
@@ -89,7 +90,8 @@ describe TokenIssuer do
       subject.set_request_handler do |url, method, body, headers|
         headers['content-type'].should =~ /application\/x-www-form-urlencoded/
         headers['accept'].should =~ /application\/json/
-        # TODO check basic auth header
+        headers['X-CF-ENCODED-CREDENTIALS'].should == 'true'
+        headers['authorization'].should == 'Basic dGVzdF9jbGllbnQ6dGVzdCUyMXNlY3JldA=='
         url.should == 'http://test.uaa.target/oauth/token'
         method.should == :post
         reply = {access_token: 'test_access_token', token_type: 'BEARER',
@@ -108,7 +110,8 @@ describe TokenIssuer do
       subject.set_request_handler do |url, method, body, headers|
         headers['content-type'].should =~ /application\/x-www-form-urlencoded/
         headers['accept'].should =~ /application\/json/
-        # TODO check basic auth header
+        headers['X-CF-ENCODED-CREDENTIALS'].should == 'true'
+        headers['authorization'].should == 'Basic dGVzdF9jbGllbnQ6dGVzdCUyMXNlY3JldA=='
         url.should == 'http://test.uaa.target/oauth/token'
         body.should =~ /(^|&)passcode=12345($|&)/
         body.should =~ /(^|&)grant_type=password($|&)/
@@ -250,7 +253,8 @@ describe TokenIssuer do
       subject.set_request_handler do |url, method, body, headers|
         headers['content-type'].should =~ /application\/x-www-form-urlencoded/
         headers['accept'].should =~ /application\/json/
-        # TODO check basic auth header
+        headers['X-CF-ENCODED-CREDENTIALS'].should == 'true'
+        headers['authorization'].should == 'Basic dGVzdF9jbGllbnQ6dGVzdCUyMXNlY3JldA=='
         url.should match 'http://test.uaa.target/oauth/token'
         method.should == :post
         reply = {access_token: 'test_access_token', token_type: 'BEARER',


### PR DESCRIPTION
and inform UAA if oauth2 encoding is set

Why:
- provide a feature option for user of cf-uaa-lib, e.g. cf-uaac
- set compatiblity header for cases where UAA allows to switch