### PR TITLE
Handle client_id/client_secret nil case.

### DIFF
--- a/lib/uaa/token_issuer.rb
+++ b/lib/uaa/token_issuer.rb
@@ -78,7 +78,7 @@ class TokenIssuer
       headers['authorization'] = Http.basic_auth(@client_id, @client_secret)
     else
       headers['X-CF-ENCODED-CREDENTIALS'] = 'true'
-      headers['authorization'] = Http.basic_auth(CGI.escape(@client_id), CGI.escape(@client_secret))
+      headers['authorization'] = Http.basic_auth(CGI.escape(@client_id || ''), CGI.escape(@client_secret || ''))
     end
     reply = json_parse_reply(@key_style, *request(@token_target, :post,
         '/oauth/token', Util.encode_form(params), headers))


### PR DESCRIPTION
The commit (e351f4d2d543631438b508f07d5043c06a6aff7b) that introduced UAA url escape encoding compatibility means client_id and client_secret can no longer be nil or an error is thrown. 

I am honestly not 100% sure if the nil case should be valid (we have a series of -- I think -- integration tests that are using nil here, so perhaps it is?). In any case, the nil case was previously supported. If the nil case is invalid, maybe this class should throw ArgumentError on instantiation instead? 

I made this change targeted within the #request_token method because I'm not sure what the possible implications would be by defaulting it in the initialize, but that might arguably be a better place for it if it does not cause a behavior change. 

One other minor note: when reading the code I found the option name `basic_auth` a little confusing, since both requests are using basic_auth. After reading about the reason for the switch, I wonder if something like "unescaped_basic_auth" (or something similar) might be a better name? If you agree, happy to also create a PR that provides both the old 'basic_auth' (for backwards compatibility) and new option.  