### PR TITLE
Remove json pure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@
 # subcomponent's license, as noted in the LICENSE file.
 #++
 
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in uaa.gemspec
 gemspec

--- a/cf-uaa-lib.gemspec
+++ b/cf-uaa-lib.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # dependencies
-  s.add_dependency 'multi_json', '>= 1.12.1', '< 1.16'
-  s.add_dependency 'json_pure', '~>2.7'
+  s.add_dependency 'json', '~>2.7'
   s.add_dependency 'httpclient', '~> 2.8', '>= 2.8.2.4'
   s.add_dependency 'addressable', '~> 2.8', '>= 2.8.0'
 
@@ -42,7 +41,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'simplecov-rcov', '~> 0.3.0'
   s.add_development_dependency 'ci_reporter', '>= 1.9.2', '~> 2.0'
-  s.add_development_dependency 'json_pure', '~>2.7'
   s.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
-
 end

--- a/lib/uaa/util.rb
+++ b/lib/uaa/util.rb
@@ -11,8 +11,8 @@
 # subcomponent's license, as noted in the LICENSE file.
 #++
 
-require 'json/pure'
-require "base64"
+require 'json'
+require 'base64'
 require 'logger'
 require 'uri'
 


### PR DESCRIPTION
Per the following warning printed when running specs:

> `json_pure` is deprecated and has no effect, just use `json`

In addition we are seeing errors in BOSH related to `json_pure` and rather than dive in to fixing this we would prefer to remove the problem at the source.